### PR TITLE
Add test spec

### DIFF
--- a/abis/Owned.json
+++ b/abis/Owned.json
@@ -1,0 +1,47 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "old",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "current",
+        "type": "address"
+      }
+    ],
+    "name": "NewOwner",
+    "type": "event"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_new",
+        "type": "address"
+      }
+    ],
+    "name": "setOwner",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abis/OwnedSet.json
+++ b/abis/OwnedSet.json
@@ -1,0 +1,256 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "recentBlocks",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_new",
+        "type": "address"
+      }
+    ],
+    "name": "setOwner",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "finalized",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "_initial",
+        "type": "address[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "reporter",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "reported",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "malicious",
+        "type": "bool"
+      }
+    ],
+    "name": "Report",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "currentSet",
+        "type": "address[]"
+      }
+    ],
+    "name": "ChangeFinalized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "_parentHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "_newSet",
+        "type": "address[]"
+      }
+    ],
+    "name": "InitiateChange",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "old",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "current",
+        "type": "address"
+      }
+    ],
+    "name": "NewOwner",
+    "type": "event"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "finalizeChange",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_validator",
+        "type": "address"
+      }
+    ],
+    "name": "addValidator",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_validator",
+        "type": "address"
+      }
+    ],
+    "name": "removeValidator",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_recentBlocks",
+        "type": "uint256"
+      }
+    ],
+    "name": "setRecentBlocks",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_validator",
+        "type": "address"
+      },
+      {
+        "name": "_blockNumber",
+        "type": "uint256"
+      },
+      {
+        "name": "_proof",
+        "type": "bytes"
+      }
+    ],
+    "name": "reportMalicious",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_validator",
+        "type": "address"
+      },
+      {
+        "name": "_blockNumber",
+        "type": "uint256"
+      }
+    ],
+    "name": "reportBenign",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getValidators",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getPending",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/abis/ValidatorSet.json
+++ b/abis/ValidatorSet.json
@@ -1,0 +1,82 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "_parentHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "name": "_newSet",
+        "type": "address[]"
+      }
+    ],
+    "name": "InitiateChange",
+    "type": "event"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "finalizeChange",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "name": "blockNumber",
+        "type": "uint256"
+      }
+    ],
+    "name": "reportBenign",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "name": "blockNumber",
+        "type": "uint256"
+      },
+      {
+        "name": "proof",
+        "type": "bytes"
+      }
+    ],
+    "name": "reportMalicious",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getValidators",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/contracts/OwnedSet.sol
+++ b/contracts/OwnedSet.sol
@@ -60,6 +60,16 @@ contract OwnedSet is Owned, ValidatorSet {
 		_;
 	}
 
+	/// Asserts whether a given address is currently a validator. A validator
+	/// that is pending to be added is not considered a validator, only when
+	/// that change is finalized will this method return true. A validator that
+	/// is pending to be removed is immediately not considered a validator
+	/// (before the change is finalized).
+	///
+	/// For the purposes of this contract one of the consequences is that you
+	/// can't report on a validator that is currently active but pending to be
+	/// removed. This is a compromise for simplicity since the reporting
+	/// functions only emit events which can be tracked off-chain.
 	modifier isValidator(address _someone) {
 		bool isIn = status[_someone].isIn;
 		uint index = status[_someone].index;

--- a/contracts/OwnedSet.sol
+++ b/contracts/OwnedSet.sol
@@ -121,8 +121,7 @@ contract OwnedSet is Owned, ValidatorSet {
 		pending.length--;
 
 		// Reset address status
-		delete status[_validator].index;
-		status[_validator].isIn = false;
+		delete status[_validator];
 
 		initiateChange();
 	}

--- a/contracts/OwnedSet.sol
+++ b/contracts/OwnedSet.sol
@@ -46,19 +46,13 @@ contract OwnedSet is Owned, ValidatorSet {
 
 	// MODIFIERS
 	modifier onlySystemAndNotFinalized() {
-		require(msg.sender != SYSTEM_ADDRESS || finalized);
+		require(msg.sender == SYSTEM_ADDRESS && !finalized);
 		_;
 	}
 
 	modifier whenFinalized() {
-		require(!finalized);
+		require(finalized);
 		_;
-	}
-
-	modifier isValidator(address _someone) {
-		if (pendingStatus[_someone].isIn) {
-			_;
-		}
 	}
 
 	modifier isPending(address _someone) {
@@ -148,7 +142,7 @@ contract OwnedSet is Owned, ValidatorSet {
 	function reportBenign(address _validator, uint _blockNumber)
 		external
 		onlyOwner
-		isValidator(_validator)
+		isPending(_validator)
 		isRecent(_blockNumber)
 	{
 		emit Report(msg.sender, _validator, false);

--- a/contracts/OwnedSet.sol
+++ b/contracts/OwnedSet.sol
@@ -39,7 +39,7 @@ contract OwnedSet is Owned, ValidatorSet {
 	// Current list of addresses entitled to participate in the consensus.
 	address[] validators;
 	address[] pending;
-	mapping(address => AddressStatus) pendingStatus;
+	mapping(address => AddressStatus) status;
 
 	// Was the last validator change finalized. Implies validators == pending
 	bool public finalized;
@@ -56,12 +56,12 @@ contract OwnedSet is Owned, ValidatorSet {
 	}
 
 	modifier isPending(address _someone) {
-		require(pendingStatus[_someone].isIn);
+		require(status[_someone].isIn);
 		_;
 	}
 
 	modifier isNotPending(address _someone) {
-		require(!pendingStatus[_someone].isIn);
+		require(!status[_someone].isIn);
 		_;
 	}
 
@@ -75,8 +75,8 @@ contract OwnedSet is Owned, ValidatorSet {
 	{
 		pending = _initial;
 		for (uint i = 0; i < _initial.length; i++) {
-			pendingStatus[_initial[i]].isIn = true;
-			pendingStatus[_initial[i]].index = i;
+			status[_initial[i]].isIn = true;
+			status[_initial[i]].index = i;
 		}
 		validators = pending;
 	}
@@ -97,8 +97,8 @@ contract OwnedSet is Owned, ValidatorSet {
 		onlyOwner
 		isNotPending(_validator)
 	{
-		pendingStatus[_validator].isIn = true;
-		pendingStatus[_validator].index = pending.length;
+		status[_validator].isIn = true;
+		status[_validator].index = pending.length;
 		pending.push(_validator);
 		initiateChange();
 	}
@@ -111,15 +111,15 @@ contract OwnedSet is Owned, ValidatorSet {
 	{
 		// Remove validator from pending by moving the
 		// last element to its slot
-		uint index = pendingStatus[_validator].index;
+		uint index = status[_validator].index;
 		pending[index] = pending[pending.length - 1];
-		pendingStatus[pending[index]].index = index;
+		status[pending[index]].index = index;
 		delete pending[pending.length - 1];
 		pending.length--;
 
 		// Reset address status
-		delete pendingStatus[_validator].index;
-		pendingStatus[_validator].isIn = false;
+		delete status[_validator].index;
+		status[_validator].isIn = false;
 
 		initiateChange();
 	}

--- a/contracts/OwnedSet.sol
+++ b/contracts/OwnedSet.sol
@@ -45,13 +45,18 @@ contract OwnedSet is Owned, ValidatorSet {
 	bool public finalized;
 
 	// MODIFIERS
-	modifier onlySystemAndNotFinalized() {
-		require(msg.sender == SYSTEM_ADDRESS && !finalized);
+	modifier onlySystem() {
+		require(msg.sender == SYSTEM_ADDRESS);
 		_;
 	}
 
 	modifier whenFinalized() {
 		require(finalized);
+		_;
+	}
+
+	modifier whenNotFinalized() {
+		require(!finalized);
 		_;
 	}
 
@@ -87,7 +92,7 @@ contract OwnedSet is Owned, ValidatorSet {
 	// Called when an initiated change reaches finality and is activated.
 	function finalizeChange()
 		external
-		onlySystemAndNotFinalized
+		onlySystem
 	{
 		finalizeChangeInternal();
 	}
@@ -182,6 +187,7 @@ contract OwnedSet is Owned, ValidatorSet {
 	// contracts inheriting it (e.g. for mocking in tests).
 	function finalizeChangeInternal()
 		internal
+		whenNotFinalized
 	{
 		validators = pending;
 		finalized = true;

--- a/contracts/OwnedSet.sol
+++ b/contracts/OwnedSet.sol
@@ -69,7 +69,7 @@ contract OwnedSet is Owned, ValidatorSet {
 	}
 
 	modifier isRecent(uint _blockNumber) {
-		require(block.number <= _blockNumber + recentBlocks);
+		require(block.number <= _blockNumber + recentBlocks && _blockNumber < block.number);
 		_;
 	}
 

--- a/contracts/OwnedSet.sol
+++ b/contracts/OwnedSet.sol
@@ -74,7 +74,7 @@ contract OwnedSet is Owned, ValidatorSet {
 		public
 	{
 		pending = _initial;
-		for (uint i = 0; i < _initial.length - 1; i++) {
+		for (uint i = 0; i < _initial.length; i++) {
 			pendingStatus[_initial[i]].isIn = true;
 			pendingStatus[_initial[i]].index = i;
 		}

--- a/contracts/OwnedSet.sol
+++ b/contracts/OwnedSet.sol
@@ -109,12 +109,18 @@ contract OwnedSet is Owned, ValidatorSet {
 		onlyOwner
 		isPending(_validator)
 	{
-		pending[pendingStatus[_validator].index] = pending[pending.length - 1];
+		// Remove validator from pending by moving the
+		// last element to its slot
+		uint index = pendingStatus[_validator].index;
+		pending[index] = pending[pending.length - 1];
+		pendingStatus[pending[index]].index = index;
 		delete pending[pending.length - 1];
 		pending.length--;
-		// Reset address status.
+
+		// Reset address status
 		delete pendingStatus[_validator].index;
 		pendingStatus[_validator].isIn = false;
+
 		initiateChange();
 	}
 

--- a/contracts/OwnedSet.sol
+++ b/contracts/OwnedSet.sol
@@ -139,7 +139,8 @@ contract OwnedSet is Owned, ValidatorSet {
 	// Report that a validator has misbehaved maliciously.
 	function reportMalicious(address _validator, uint _blockNumber, bytes _proof)
 		external
-		onlyOwner
+		isValidator(msg.sender)
+		isValidator(_validator)
 		isRecent(_blockNumber)
 	{
 		emit Report(msg.sender, _validator, true);
@@ -148,7 +149,7 @@ contract OwnedSet is Owned, ValidatorSet {
 	// Report that a validator has misbehaved in a benign way.
 	function reportBenign(address _validator, uint _blockNumber)
 		external
-		onlyOwner
+		isValidator(msg.sender)
 		isValidator(_validator)
 		isRecent(_blockNumber)
 	{

--- a/contracts/OwnedSet.sol
+++ b/contracts/OwnedSet.sol
@@ -55,12 +55,15 @@ contract OwnedSet is Owned, ValidatorSet {
 		_;
 	}
 
-	modifier isPending(address _someone) {
-		require(status[_someone].isIn);
+	modifier isValidator(address _someone) {
+		bool isIn = status[_someone].isIn;
+		uint index = status[_someone].index;
+
+		require(isIn && index < validators.length && validators[index] == _someone);
 		_;
 	}
 
-	modifier isNotPending(address _someone) {
+	modifier isNotValidator(address _someone) {
 		require(!status[_someone].isIn);
 		_;
 	}
@@ -95,7 +98,7 @@ contract OwnedSet is Owned, ValidatorSet {
 	function addValidator(address _validator)
 		external
 		onlyOwner
-		isNotPending(_validator)
+		isNotValidator(_validator)
 	{
 		status[_validator].isIn = true;
 		status[_validator].index = pending.length;
@@ -107,7 +110,7 @@ contract OwnedSet is Owned, ValidatorSet {
 	function removeValidator(address _validator)
 		external
 		onlyOwner
-		isPending(_validator)
+		isValidator(_validator)
 	{
 		// Remove validator from pending by moving the
 		// last element to its slot
@@ -146,7 +149,7 @@ contract OwnedSet is Owned, ValidatorSet {
 	function reportBenign(address _validator, uint _blockNumber)
 		external
 		onlyOwner
-		isPending(_validator)
+		isValidator(_validator)
 		isRecent(_blockNumber)
 	{
 		emit Report(msg.sender, _validator, false);

--- a/contracts/OwnedSet.sol
+++ b/contracts/OwnedSet.sol
@@ -86,9 +86,7 @@ contract OwnedSet is Owned, ValidatorSet {
 		external
 		onlySystemAndNotFinalized
 	{
-		validators = pending;
-		finalized = true;
-		emit ChangeFinalized(getValidators());
+		finalizeChangeInternal();
 	}
 
 	// OWNER FUNCTIONS
@@ -166,6 +164,19 @@ contract OwnedSet is Owned, ValidatorSet {
 		returns (address[])
 	{
 		return pending;
+	}
+
+	// INTERNAL
+
+	// Called when an initiated change reaches finality and is activated.
+	// This method is defined with no modifiers so it can be reused by
+	// contracts inheriting it (e.g. for mocking in tests).
+	function finalizeChangeInternal()
+		internal
+	{
+		validators = pending;
+		finalized = true;
+		emit ChangeFinalized(getValidators());
 	}
 
 	// PRIVATE

--- a/contracts/TestOwnedSet.sol
+++ b/contracts/TestOwnedSet.sol
@@ -30,16 +30,16 @@ contract TestOwnedSet is OwnedSet {
 		systemAddress = _systemAddress;
 	}
 
-	// expose `pendingStatus` to use for assertions in tests
-	function getPendingStatus(address _validator)
+	// expose `status` to use for assertions in tests
+	function getStatus(address _validator)
 		public
 		view
 		returns (bool isIn, uint index)
 	{
-		AddressStatus storage status = pendingStatus[_validator];
+		AddressStatus storage addressStatus = status[_validator];
 
-		isIn = status.isIn;
-		index = status.index;
+		isIn = addressStatus.isIn;
+		index = addressStatus.index;
 	}
 
 	// re-declare these methods to use the mocked system address

--- a/contracts/TestOwnedSet.sol
+++ b/contracts/TestOwnedSet.sol
@@ -1,0 +1,57 @@
+// Copyright 2018 Parity Technologies Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A testable version of the `OwnedSet` contract that exposes some internal
+// state and allows setting the system address.
+
+pragma solidity ^0.4.22;
+
+import "./OwnedSet.sol";
+
+
+contract TestOwnedSet is OwnedSet {
+	// allow mocking system address
+	address systemAddress;
+
+	constructor(address _systemAddress, address[] _initial) OwnedSet(_initial)
+		public
+	{
+		systemAddress = _systemAddress;
+	}
+
+	// expose `pendingStatus` to use for assertions in tests
+	function getPendingStatus(address _validator)
+		public
+		view
+		returns (bool isIn, uint index)
+	{
+		AddressStatus storage status = pendingStatus[_validator];
+
+		isIn = status.isIn;
+		index = status.index;
+	}
+
+	// re-declare these methods to use the mocked system address
+	modifier onlySystemAndNotFinalized() {
+		require(msg.sender == systemAddress && !finalized);
+		_;
+	}
+
+	function finalizeChange()
+		external
+		onlySystemAndNotFinalized
+	{
+		finalizeChangeInternal();
+	}
+}

--- a/contracts/TestOwnedSet.sol
+++ b/contracts/TestOwnedSet.sol
@@ -43,14 +43,14 @@ contract TestOwnedSet is OwnedSet {
 	}
 
 	// re-declare these methods to use the mocked system address
-	modifier onlySystemAndNotFinalized() {
-		require(msg.sender == systemAddress && !finalized);
+	modifier onlySystem() {
+		require(msg.sender == systemAddress);
 		_;
 	}
 
 	function finalizeChange()
 		external
-		onlySystemAndNotFinalized
+		onlySystem
 	{
 		finalizeChangeInternal();
 	}

--- a/test/owned_set.js
+++ b/test/owned_set.js
@@ -48,7 +48,7 @@ contract("TestOwnedSet", accounts => {
 
     // every validator should be added to the `pendingStatus` map
     for (let [index, acc] of expected.entries()) {
-      let [isIn, idx] = await set.getPendingStatus(acc);
+      let [isIn, idx] = await set.getStatus(acc);
       assert(isIn);
       assert.equal(idx, index);
     }
@@ -124,7 +124,7 @@ contract("TestOwnedSet", accounts => {
     );
 
     // `pendingStatus` should be updated
-    const [isIn, index] = await set.getPendingStatus(accounts[3]);
+    const [isIn, index] = await set.getStatus(accounts[3]);
     assert(isIn);
     assert.equal(index, 3);
 
@@ -185,7 +185,7 @@ contract("TestOwnedSet", accounts => {
     );
 
     // `pendingStatus` should be updated
-    const [isIn, index] = await set.getPendingStatus(accounts[3]);
+    const [isIn, index] = await set.getStatus(accounts[3]);
     assert(!isIn);
     assert.equal(index, 0);
 

--- a/test/owned_set.js
+++ b/test/owned_set.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const TestOwnedSet = artifacts.require("./TestOwnedSet.sol");
+
+contract("TestOwnedSet", accounts => {
+  const assertThrowsAsync = async (fn, msg) => {
+    try {
+      await fn();
+    } catch (err) {
+      assert(err.message.includes(msg), "Expected error to include: " + msg);
+      return;
+    }
+    assert.fail("Expected fn to throw");
+  };
+
+  const SYSTEM = accounts[9];
+  const INITIAL_VALIDATORS = [accounts[0], accounts[1], accounts[2]];
+
+  let _ownedSet;
+  const ownedSet = async () => {
+    if (_ownedSet === undefined) {
+      _ownedSet = await TestOwnedSet.new(
+        SYSTEM,
+        INITIAL_VALIDATORS,
+      );
+    }
+
+    return _ownedSet;
+  };
+
+  it("should initialize the pending and validators set on creation", async () => {
+    const set = await ownedSet();
+
+    const validators = await set.getValidators();
+    const pending = await set.getPending();
+
+    const expected = INITIAL_VALIDATORS;
+
+    // both the pending and current validator set should point to the initial set
+    assert.deepEqual(validators, expected);
+    assert.deepEqual(pending, expected);
+
+    const finalized = await set.finalized();
+
+    // the change should not be finalized
+    assert(!finalized);
+
+    // every validator should be added to the `pendingStatus` map
+    for (let [index, acc] of expected.entries()) {
+      let [isIn, idx] = await set.getPendingStatus(acc);
+      assert(isIn);
+      assert.equal(idx, index);
+    }
+  });
+});

--- a/test/owned_set.js
+++ b/test/owned_set.js
@@ -222,7 +222,7 @@ contract("TestOwnedSet", accounts => {
 
     // disallowed because previous change hasn't been finalized yet
     await assertThrowsAsync(
-      () => set.removeValidator(accounts[3], { from: OWNER }),
+      () => set.removeValidator(accounts[2], { from: OWNER }),
       "revert",
     );
 
@@ -237,59 +237,59 @@ contract("TestOwnedSet", accounts => {
     );
   });
 
-  it("should allow the owner to report misbehaviour", async () => {
+  it("should allow current validators to report misbehaviour", async () => {
     const set = await ownedSet();
     const watcher = set.Report();
 
-    // only the owner can report misbehaviour
+    // only current validators can report misbehaviour
     await assertThrowsAsync(
       () => set.reportMalicious(
-        accounts[2],
+        INITIAL_VALIDATORS[0],
         web3.eth.blockNumber - 1,
         [],
-        { from: accounts[1] },
+        { from: accounts[8] },
       ),
       "revert",
     );
 
     await assertThrowsAsync(
       () => set.reportBenign(
-        accounts[2],
+        INITIAL_VALIDATORS[0],
         web3.eth.blockNumber - 1,
-        { from: accounts[1] },
+        { from: accounts[8] },
       ),
       "revert",
     );
 
     // successfully report malicious misbehaviour
     await set.reportMalicious(
-      accounts[2],
+      INITIAL_VALIDATORS[0],
       web3.eth.blockNumber - 1,
       [],
-      { from: OWNER },
+      { from: INITIAL_VALIDATORS[1] },
     );
 
     // it should emit a `Report` event
     let events = await watcher.get();
 
     assert.equal(events.length, 1);
-    assert.equal(events[0].args.reporter, OWNER);
-    assert.equal(events[0].args.reported, accounts[2]);
+    assert.equal(events[0].args.reporter, INITIAL_VALIDATORS[1]);
+    assert.equal(events[0].args.reported, INITIAL_VALIDATORS[0]);
     assert(events[0].args.malicious);
 
     // successfully report benign misbehaviour
     await set.reportBenign(
-      accounts[2],
+      INITIAL_VALIDATORS[0],
       web3.eth.blockNumber - 1,
-      { from: OWNER },
+      { from: INITIAL_VALIDATORS[1] },
     );
 
     // it should emit a `Report` event
     events = await watcher.get();
 
     assert.equal(events.length, 1);
-    assert.equal(events[0].args.reporter, OWNER);
-    assert.equal(events[0].args.reported, accounts[2]);
+    assert.equal(events[0].args.reporter, INITIAL_VALIDATORS[1]);
+    assert.equal(events[0].args.reported, INITIAL_VALIDATORS[0]);
     assert(!events[0].args.malicious);
   });
 


### PR DESCRIPTION
Created a test spec for the `OwnedSet` contract. I had to create a `TestOwnedSet` contract which inherits from `OwnedSet` and exposes some of its inner state (for asserting in tests) and also allows setting the system address, so we can mock calls to `finalizeChange` in the tests. Also fixed a couple of issues that I found during tests.
Also closes #8.

Merge after #6.